### PR TITLE
refactor: source shared helpers directly

### DIFF
--- a/apps/web/app/api/weights/[id]/route.ts
+++ b/apps/web/app/api/weights/[id]/route.ts
@@ -1,12 +1,11 @@
 import { NextResponse } from 'next/server';
 
+import { makeWeightStore, type WeightEntry } from '../../../../lib/store/serverFactory';
 import {
   isValidIsoTimestamp,
   isValidLocalDate,
   isValidLocalTime,
-  makeWeightStore,
-  type WeightEntry,
-} from '../../../../lib/store/serverFactory';
+} from '../../../../lib/store/shared';
 
 type PatchPayload = Partial<WeightEntry>;
 

--- a/apps/web/app/api/weights/route.ts
+++ b/apps/web/app/api/weights/route.ts
@@ -1,13 +1,12 @@
 import { NextResponse } from 'next/server';
 
+import { makeWeightStore, type WeightEntry } from '../../../lib/store/serverFactory';
 import {
   getLocalDateParts,
   isUnit,
   isValidLocalDate,
-  makeWeightStore,
   toKgLb,
-  type WeightEntry,
-} from '../../../lib/store/serverFactory';
+} from '../../../lib/store/shared';
 
 type Mode = 'now' | 'backfill';
 

--- a/apps/web/lib/store/serverFactory.ts
+++ b/apps/web/lib/store/serverFactory.ts
@@ -3,17 +3,6 @@
 import type { WeightStore } from './shared';
 
 export type { Unit, WeightEntry, WeightStore } from './shared';
-export {
-  formatLocalDate,
-  formatLocalTime,
-  getLocalDateParts,
-  isUnit,
-  isValidIsoTimestamp,
-  isValidLocalDate,
-  isValidLocalTime,
-  sortWeightEntries,
-  toKgLb,
-} from './shared';
 
 async function loadLocalStore(): Promise<WeightStore> {
   const { createLocalStorageWeightStore } = await import('./localStorageWeightStore');


### PR DESCRIPTION
## Summary
- stop re-exporting shared helper functions from the serverFactory entrypoint
- update weight API routes to import validation helpers straight from the shared module

## Testing
- pnpm --filter web build

------
https://chatgpt.com/codex/tasks/task_e_68d1b7b4f55c832080f839a5371f52d6